### PR TITLE
Bug occurs when the clang & -O2

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -23,6 +23,23 @@ header = |$pkg->add_xs('Parser.xs');
 header = |$pkg->add_pm('lib/B/Hooks/Parser.pm' => '$(INST_LIB)/B/Hooks/Parser.pm');
 WriteMakefile_arg = $pkg->get_makefile_vars
 WriteMakefile_arg = FUNCLIST => [ qw/hook_parser_setup hook_parser_teardown hook_parser_get_linestr hook_parser_get_linestr_offset hook_parser_set_linestr hook_parser_get_lex_stuff hook_parser_clear_lex_stuff hook_toke_skipspace hook_toke_scan_str hook_toke_scan_word/, 'boot_B__Hooks__Parser' ]
+footer = |sub MY::cflags {
+footer = |    package MY;
+footer = |    my $self = shift;
+footer = |    my $out  = $self->SUPER::cflags(@_);
+footer = |    if ($self->{CCFLAGS} =~ /\b-O1|-O2|-O3|-Ofast|-Os|-Oz|-O|-O4\b/) {
+footer = |        my $useithreads = `$self->{PERL} -V::useithreads`;
+footer = |        chomp $useithreads;
+footer = |        if ($useithreads eq "'define';") {
+footer = |            my $cc_version = `$self->{CC} --version`;
+footer = |            chomp $cc_version;
+footer = |            if ($cc_version =~ /clang/) {
+footer = |                $out .= "\nCCFLAGS += -O0";
+footer = |            }
+footer = |        }
+footer = |    }
+footer = |    $out;
+footer = |}
 
 [Prereqs / ConfigureRequires]
 ExtUtils::Depends = 0.302   ; minimum version that works on Win32+gcc

--- a/dist.ini
+++ b/dist.ini
@@ -27,14 +27,14 @@ footer = |sub MY::cflags {
 footer = |    package MY;
 footer = |    my $self = shift;
 footer = |    my $out  = $self->SUPER::cflags(@_);
-footer = |    if ($self->{CCFLAGS} =~ /\b-O1|-O2|-O3|-Ofast|-Os|-Oz|-O|-O4\b/) {
+footer = |    if ($out =~ /^(?:CCFLAGS|OPTIMIZE).*\b-O1|-O2|-O3|-Ofast|-Os|-Oz|-O|-O4\b/m) {
 footer = |        my $useithreads = `$self->{PERL} -V::useithreads`;
 footer = |        chomp $useithreads;
 footer = |        if ($useithreads eq "'define';") {
 footer = |            my $cc_version = `$self->{CC} --version`;
 footer = |            chomp $cc_version;
 footer = |            if ($cc_version =~ /clang/) {
-footer = |                $out .= "\nCCFLAGS += -O0";
+footer = |                $out =~ s/^((?:CCFLAGS|OPTIMIZE).*)\b-O1|-O2|-O3|-Ofast|-Os|-Oz|-O|-O4\b/$1/g;
 footer = |            }
 footer = |        }
 footer = |    }


### PR DESCRIPTION
Hello.

I encounter the bug at Hook::AfterRuntime on FreeBSD 10.
Perl process is not the end, core dump file is output.
In addition, If it make test in /usr/ports/devel/p5-B-Hooks-Parser/, the test will fail.

After trial and error, it was found that the test fails in the case of a clang & useithreads.
I wrote a patch.

It may have been associated with https://rt.cpan.org/Public/Bug/Display.html?id=94463

Although it was also thought to modify the ports file (/usr/ports/devel/p5-B-Hooks-Parser/Makefile) side,
also have been reported in the above ticket, better to cope with Perl side I thought it was good.

If there is no problem, please merge.

Cheers
Tomohiro Hosaka

make test log

```
Script started on Sun Jul 19 12:05:50 2015
root # uname -a
FreeBSD af5b5a3f-2b96-11e5-8d10-0025229f7519 10.1-RELEASE-p10 FreeBSD 10.1-RELEASE-p10 #0: Wed May 13 06:54:13 UTC 2015     root@amd64-builder.daemonology.net:/usr/obj/usr/src/sys/GENERIC  amd64
root # pwd
/usr/ports/devel/p5-B-Hooks-Parser
root # make -d x test
+ [ -f /var/db/pkg/vuln.xml ]
+ [ -x /usr/local/sbin/pkg-static ]
+ /usr/local/sbin/pkg-static audit p5-B-Hooks-Parser-0.13_2
+ vlist='0 problem(s) in the installed packages found.'
+ [ '0 problem(s) in the installed packages found.' = '0 problem(s) in the installed packages found.' ]
+ vlist=''
+ [ -n '' ]
+ /usr/bin/env dp_RAWDEPENDS=/usr/local/sbin/pkg:/usr/ports/ports-mgmt/pkg dp_DEPTYPE=PKG_DEPENDS dp_DEPENDS_TARGET=install dp_DEPENDS_PRECLEAN= dp_DEPENDS_CLEAN= dp_DEPENDS_ARGS= dp_USE_PACKAGE_DEPENDS= dp_USE_PACKAGE_DEPENDS_ONLY= 'dp_PKG_ADD=/usr/local/sbin/pkg-static add' 'dp_PKG_INFO=/usr/local/sbin/pkg-static info -g' dp_WRKDIR=/usr/ports/devel/p5-B-Hooks-Parser/work dp_PKGNAME=p5-B-Hooks-Parser-0.13_2 dp_STRICT_DEPENDS= dp_LOCALBASE=/usr/local 'dp_LIB_DIRS=/lib /usr/lib /usr/local/lib' dp_SH=/bin/sh dp_SCRIPTSDIR=/usr/ports/Mk/Scripts dp_PORTSDIR=/usr/ports dp_MAKE=make /bin/sh /usr/ports/Mk/Scripts/do-depends.sh
===>   p5-B-Hooks-Parser-0.13_2 depends on file: /usr/local/sbin/pkg - found
+ cd /usr/ports/distfiles/
+ _MASTER_SITES_DEFAULT='http://cpan.metacpan.org/modules/by-module/B/ http://www.cpan.org/modules/by-module/B/ ftp://ftp.cpan.org/pub/CPAN/modules/by-module/B/ http://www.cpan.dk/modules/by-module/B/ ftp://ftp.kddlabs.co.jp/lang/perl/CPAN/modules/by-module/B/ http://ftp.jaist.ac.jp/pub/CPAN/modules/by-module/B/ ftp://ftp.sunet.se/pub/lang/perl/CPAN/modules/by-module/B/ ftp://ftp.mirrorservice.org/sites/cpan.perl.org/CPAN/modules/by-module/B/ ftp://ftp.auckland.ac.nz/pub/perl/CPAN/modules/by-module/B/ http://backpan.perl.org/modules/by-module/B/ ftp://ftp.funet.fi/pub/languages/perl/CPAN/modules/by-module/B/ http://ftp.twaren.net/Unix/Lang/CPAN/modules/by-module/B/ ftp://ftp.cpan.org/pub/CPAN/modules/by-module/B/ http://www.cpan.dk/modules/by-module/B/'
+ file=B-Hooks-Parser-0.13.tar.gz
+ [ B-Hooks-Parser-0.13.tar.gz = B-Hooks-Parser-0.13.tar.gz ]
+ select=''
+ force_fetch=false
+ filebasename=B-Hooks-Parser-0.13.tar.gz
+ [ ! -f B-Hooks-Parser-0.13.tar.gz -a ! -f B-Hooks-Parser-0.13.tar.gz -o false = true ]
+ echo '===> Fetching all distfiles required by p5-B-Hooks-Parser-0.13_2 for building'
===> Fetching all distfiles required by p5-B-Hooks-Parser-0.13_2 for building
+ echo '===>  Extracting for p5-B-Hooks-Parser-0.13_2'
===>  Extracting for p5-B-Hooks-Parser-0.13_2
+ SHA256=/sbin/sha256
+ eval 'alg_executable=$SHA256'
+ alg_executable=/sbin/sha256
+ [ -z /sbin/sha256 ]
+ set -e
+ SHA256=/sbin/sha256
+ [ -f /usr/ports/devel/p5-B-Hooks-Parser/distinfo ]
+ cd /usr/ports/distfiles
+ OK=''
+ ignored=true
+ _file=B-Hooks-Parser-0.13.tar.gz
+ ignore=false
+ eval 'alg_executable=$SHA256'
+ alg_executable=/sbin/sha256
+ [ /sbin/sha256 != NO ]
+ /sbin/sha256
+ MKSUM=f6c838e59f52e21ccc0b2c9d85d6f7ba33119098ad3a261698b01690c2619646
+ file=B-Hooks-Parser-0.13.tar.gz
+ [ '(' -n '' -a -n '' ')' -o ! -f /usr/ports/devel/p5-B-Hooks-Parser/distinfo ]
+ DIR=''
+ /usr/bin/awk -v alg=SHA256 -v file=B-Hooks-Parser-0.13.tar.gz '$1 == alg && $2 == "(" file ")" {print $4}' /usr/ports/devel/p5-B-Hooks-Parser/distinfo
+ CKSUM=f6c838e59f52e21ccc0b2c9d85d6f7ba33119098ad3a261698b01690c2619646
+ [ false = false -a -z f6c838e59f52e21ccc0b2c9d85d6f7ba33119098ad3a261698b01690c2619646 ]
+ [ false = false ]
+ match=false
+ [ f6c838e59f52e21ccc0b2c9d85d6f7ba33119098ad3a261698b01690c2619646 = f6c838e59f52e21ccc0b2c9d85d6f7ba33119098ad3a261698b01690c2619646 ]
+ match=true
+ break
+ [ true = true ]
+ echo '=> SHA256 Checksum OK for B-Hooks-Parser-0.13.tar.gz.'
=> SHA256 Checksum OK for B-Hooks-Parser-0.13.tar.gz.
+ ignored=false
+ [ false = true ]
+ [ true = retry ]
+ [ true != true -a 1 -eq 0 ]
+ [ true != true ]
+ cd /usr/ports/devel/p5-B-Hooks-Parser/work
+ /usr/bin/tar -xf /usr/ports/distfiles//B-Hooks-Parser-0.13.tar.gz --no-same-owner --no-same-permissions
+ [ 0 = 0 ]
+ /bin/chmod -R ug-s /usr/ports/devel/p5-B-Hooks-Parser/work
+ /usr/sbin/chown -R 0:0 /usr/ports/devel/p5-B-Hooks-Parser/work
+ echo '===>  Patching for p5-B-Hooks-Parser-0.13_2'
===>  Patching for p5-B-Hooks-Parser-0.13_2
+ set -e
+ [ -d /usr/ports/devel/p5-B-Hooks-Parser/files ]
+ /usr/bin/env 'dp_RAWDEPENDS=p5-B-Hooks-OP-Check>=0:/usr/ports/devel/p5-B-Hooks-OP-Check  p5-ExtUtils-Depends>=0.302:/usr/ports/devel/p5-ExtUtils-Depends /usr/local/bin/perl5.18.4:/usr/ports/lang/perl5.18' dp_DEPTYPE=BUILD_DEPENDS dp_DEPENDS_TARGET=install dp_DEPENDS_PRECLEAN= dp_DEPENDS_CLEAN= dp_DEPENDS_ARGS= dp_USE_PACKAGE_DEPENDS= dp_USE_PACKAGE_DEPENDS_ONLY= 'dp_PKG_ADD=/usr/local/sbin/pkg-static add' 'dp_PKG_INFO=/usr/local/sbin/pkg-static info -g' dp_WRKDIR=/usr/ports/devel/p5-B-Hooks-Parser/work dp_PKGNAME=p5-B-Hooks-Parser-0.13_2 dp_STRICT_DEPENDS= dp_LOCALBASE=/usr/local 'dp_LIB_DIRS=/lib /usr/lib /usr/local/lib' dp_SH=/bin/sh dp_SCRIPTSDIR=/usr/ports/Mk/Scripts dp_PORTSDIR=/usr/ports dp_MAKE=make /bin/sh /usr/ports/Mk/Scripts/do-depends.sh
===>   p5-B-Hooks-Parser-0.13_2 depends on package: p5-B-Hooks-OP-Check>=0 - found
===>   p5-B-Hooks-Parser-0.13_2 depends on package: p5-ExtUtils-Depends>=0.302 - found
===>   p5-B-Hooks-Parser-0.13_2 depends on file: /usr/local/bin/perl5.18.4 - found
+ echo '===>  Configuring for p5-B-Hooks-Parser-0.13_2'
===>  Configuring for p5-B-Hooks-Parser-0.13_2
+ /usr/bin/find /usr/ports/devel/p5-B-Hooks-Parser/work -type f '(' -name config.libpath -o -name config.rpath -o -name configure -o -name libtool.m4 -o -name ltconfig -o -name libtool -o -name aclocal.m4 -o -name acinclude.m4 ')'
+ [ -f /usr/ports/devel/p5-B-Hooks-Parser/scripts/configure ]
+ cd /usr/ports/devel/p5-B-Hooks-Parser/work/B-Hooks-Parser-0.13
+ /usr/bin/env ac_cv_path_PERL=/usr/local/bin/perl ac_cv_path_PERL_PATH=/usr/local/bin/perl XDG_DATA_HOME=/usr/ports/devel/p5-B-Hooks-Parser/work XDG_CONFIG_HOME=/usr/ports/devel/p5-B-Hooks-Parser/work HOME=/usr/ports/devel/p5-B-Hooks-Parser/work SHELL=/bin/sh CONFIG_SHELL=/bin/sh PERL_EXTUTILS_AUTOINSTALL=--skipdeps /usr/local/bin/perl5.18.4 ./Makefile.PL INSTALLDIRS=site CC=cc 'CCFLAGS=-O2 -pipe  -fstack-protector -fno-strict-aliasing' PREFIX=/usr/local INSTALLPRIVLIB=/usr/local/lib INSTALLARCHLIB=/usr/local/lib
Checking if your kit is complete...
Looks good
Writing Makefile for B::Hooks::Parser
Writing MYMETA.yml and MYMETA.json
+ cd /usr/ports/devel/p5-B-Hooks-Parser/work/B-Hooks-Parser-0.13
+ /usr/local/bin/perl5.18.4 -pi -e 's/ doc_(perl|site|\$\(INSTALLDIRS\))_install$//' Makefile
+ echo '===>  Building for p5-B-Hooks-Parser-0.13_2'
===>  Building for p5-B-Hooks-Parser-0.13_2
+ cd /usr/ports/devel/p5-B-Hooks-Parser/work/B-Hooks-Parser-0.13
+ /usr/bin/env XDG_DATA_HOME=/usr/ports/devel/p5-B-Hooks-Parser/work XDG_CONFIG_HOME=/usr/ports/devel/p5-B-Hooks-Parser/work HOME=/usr/ports/devel/p5-B-Hooks-Parser/work NO_PIE=yes SHELL=/bin/sh NO_LINT=YES PREFIX=/usr/local LOCALBASE=/usr/local LIBDIR=/usr/lib CC=cc 'CFLAGS=-O2 -pipe  -fstack-protector -fno-strict-aliasing' CPP=cpp CPPFLAGS= 'LDFLAGS= -fstack-protector' LIBS= CXX=c++ 'CXXFLAGS=-O2 -pipe -fstack-protector -fno-strict-aliasing ' MANPREFIX=/usr/local 'BSD_INSTALL_PROGRAM=install  -s -m 555' 'BSD_INSTALL_LIB=install  -s -m 444' 'BSD_INSTALL_SCRIPT=install  -m 555' 'BSD_INSTALL_DATA=install  -m 0644' 'BSD_INSTALL_MAN=install  -m 444' /usr/bin/make -f Makefile -j8 all
--- blib/lib/B/Hooks/.exists ---
--- blib/arch/.exists ---
--- blib/lib/auto/B/Hooks/Parser/.exists ---
--- blib/arch/auto/B/Hooks/Parser/.exists ---
--- blib/bin/.exists ---
--- blib/script/.exists ---
--- blib/man1/.exists ---
--- blib/man3/.exists ---
--- blib/lib/B/Hooks/.exists ---
+ /usr/local/bin/perl5.18.4 -MExtUtils::Command -e mkpath -- blib/lib/B/Hooks
--- blib/arch/.exists ---
+ /usr/local/bin/perl5.18.4 -MExtUtils::Command -e mkpath -- blib/arch
--- blib/lib/auto/B/Hooks/Parser/.exists ---
+ /usr/local/bin/perl5.18.4 -MExtUtils::Command -e mkpath -- blib/lib/auto/B/Hooks/Parser
--- blib/arch/auto/B/Hooks/Parser/.exists ---
+ /usr/local/bin/perl5.18.4 -MExtUtils::Command -e mkpath -- blib/arch/auto/B/Hooks/Parser
--- blib/bin/.exists ---
+ /usr/local/bin/perl5.18.4 -MExtUtils::Command -e mkpath -- blib/bin
--- blib/script/.exists ---
+ /usr/local/bin/perl5.18.4 -MExtUtils::Command -e mkpath -- blib/script
--- blib/man1/.exists ---
+ /usr/local/bin/perl5.18.4 -MExtUtils::Command -e mkpath -- blib/man1
--- blib/man3/.exists ---
+ /usr/local/bin/perl5.18.4 -MExtUtils::Command -e mkpath -- blib/man3
+ + + + + + + + + + + + + + + + --- subdirs ---
--- Parser.c ---
--- pm_to_blib ---
+ true
+ --- blibdirs ---
--- Parser.bs ---
--- Parser.c ---
/usr/local/bin/perl5.18.4 /usr/local/lib/perl5/5.18/ExtUtils/xsubpp  -typemap /usr/local/lib/perl5/5.18/ExtUtils/typemap  Parser.xs > Parser.xsc && mv Parser.xsc Parser.c
+ /usr/local/bin/perl5.18.4 /usr/local/lib/perl5/5.18/ExtUtils/xsubpp -typemap /usr/local/lib/perl5/5.18/ExtUtils/typemap Parser.xs
--- pm_to_blib ---
+ /usr/local/bin/perl5.18.4 -MExtUtils::Install -e 'pm_to_blib({@ARGV}, '\''blib/lib/auto'\'', q[], '\''755'\'')' -- hook_parser.h blib/arch/B/Hooks/Parser/Install/hook_parser.h lib/B/Hooks/Parser.pm blib/lib/B/Hooks/Parser.pm
--- blibdirs ---
+ true
+ --- config ---
+ echo 'Running Mkbootstrap for B::Hooks::Parser ()'
Running Mkbootstrap for B::Hooks::Parser ()
+ + + true
+ --- Parser.bs ---
chmod 644 Parser.bs
--- blib/arch/auto/B/Hooks/Parser/Parser.bs ---
+ rm -rf blib/arch/auto/B/Hooks/Parser/Parser.bs
+ + cp Parser.bs blib/arch/auto/B/Hooks/Parser/Parser.bs
chmod 644 blib/arch/auto/B/Hooks/Parser/Parser.bs
--- pm_to_blib ---
cp hook_parser.h blib/arch/B/Hooks/Parser/Install/hook_parser.h
cp lib/B/Hooks/Parser.pm blib/lib/B/Hooks/Parser.pm
+ + --- Parser.c ---
+ mv Parser.xsc Parser.c
--- Parser.o ---
cc -c  -I/usr/local/lib/perl5/site_perl/mach/5.18/B/Hooks/OP/Check/Install  -O2 -pipe  -fstack-protector -fno-strict-aliasing -g    -DVERSION=\"0.13\"  -DXS_VERSION=\"0.13\" -DPIC -fPIC "-I/usr/local/lib/perl5/5.18/mach/CORE"   Parser.c
+ cc -c -I/usr/local/lib/perl5/site_perl/mach/5.18/B/Hooks/OP/Check/Install -O2 -pipe -fstack-protector -fno-strict-aliasing -g '-DVERSION="0.13"' '-DXS_VERSION="0.13"' -DPIC -fPIC -I/usr/local/lib/perl5/5.18/mach/CORE Parser.c
In file included from Parser.xs:9:
./stolen_chunk_of_toke.c:350:38: warning: 'Perl_is_utf8_mark' is deprecated [-Wdeprecated-declarations]
            while (UTF8_IS_CONTINUED(*t) && is_utf8_mark((U8*)t))
                                            ^
/usr/local/lib/perl5/5.18/mach/CORE/embed.h:275:26: note: expanded from macro 'is_utf8_mark'
#define is_utf8_mark(a)         Perl_is_utf8_mark(aTHX_ a)
                                ^
/usr/local/lib/perl5/5.18/mach/CORE/proto.h:1974:20: note: 'Perl_is_utf8_mark' declared here
PERL_CALLCONV bool      Perl_is_utf8_mark(pTHX_ const U8 *p)
                        ^
In file included from Parser.xs:9:
./stolen_chunk_of_toke.c:546:13: warning: 'Perl_utf8_to_uvchr' is deprecated [-Wdeprecated-declarations]
        termcode = utf8_to_uvchr((U8*)s, &termlen);
                   ^
/usr/local/lib/perl5/5.18/mach/CORE/embed.h:691:28: note: expanded from macro 'utf8_to_uvchr'
#define utf8_to_uvchr(a,b)      Perl_utf8_to_uvchr(aTHX_ a,b)
                                ^
/usr/local/lib/perl5/5.18/mach/CORE/proto.h:4696:18: note: 'Perl_utf8_to_uvchr' declared here
PERL_CALLCONV UV        Perl_utf8_to_uvchr(pTHX_ const U8 *s, STRLEN *retlen)
                        ^
2 warnings generated.
--- blib/arch/auto/B/Hooks/Parser/Parser.so ---
rm -f blib/arch/auto/B/Hooks/Parser/Parser.so
+ rm -f blib/arch/auto/B/Hooks/Parser/Parser.so
cc  -shared  -L/wrkdirs/usr/ports/lang/perl5.18/work/perl-5.18.4 -L/usr/local/lib/perl5/5.18/mach/CORE -Wl,-rpath=/usr/local/lib/perl5/5.18/mach/CORE -lperl -L/usr/local/lib -fstack-protector Parser.o  -o blib/arch/auto/B/Hooks/Parser/Parser.so             
+ cc -shared -L/wrkdirs/usr/ports/lang/perl5.18/work/perl-5.18.4 -L/usr/local/lib/perl5/5.18/mach/CORE -Wl,-rpath=/usr/local/lib/perl5/5.18/mach/CORE -lperl -L/usr/local/lib -fstack-protector Parser.o -o blib/arch/auto/B/Hooks/Parser/Parser.so
chmod 755 blib/arch/auto/B/Hooks/Parser/Parser.so
+ chmod 755 blib/arch/auto/B/Hooks/Parser/Parser.so
--- dynamic ---
+ true
+ --- linkext ---
+ true
+ --- pure_all ---
+ true
+ --- manifypods ---
+ /usr/local/bin/perl5.18.4 -MExtUtils::Command::MM -e pod2man -- --section=3 --perm_rw=644 lib/B/Hooks/Parser.pm blib/man3/B::Hooks::Parser.3
Manifying blib/man3/B::Hooks::Parser.3
+ --- all ---
+ true
+ cd /usr/ports/devel/p5-B-Hooks-Parser/work/B-Hooks-Parser-0.13/ && /usr/bin/env XDG_DATA_HOME=/usr/ports/devel/p5-B-Hooks-Parser/work  XDG_CONFIG_HOME=/usr/ports/devel/p5-B-Hooks-Parser/work  HOME=/usr/ports/devel/p5-B-Hooks-Parser/work NO_PIE=yes SHELL=/bin/sh NO_LINT=YES PREFIX=/usr/local  LOCALBASE=/usr/local  LIBDIR="/usr/lib"  CC="cc" CFLAGS="-O2 -pipe  -fstack-protector -fno-strict-aliasing"  CPP="cpp" CPPFLAGS=""  LDFLAGS=" -fstack-protector" LIBS=""  CXX="c++" CXXFLAGS="-O2 -pipe -fstack-protector -fno-strict-aliasing "  MANPREFIX="/usr/local" BSD_INSTALL_PROGRAM="install  -s -m 555"  BSD_INSTALL_LIB="install  -s -m 444"  BSD_INSTALL_SCRIPT="install  -m 555"  BSD_INSTALL_DATA="install  -m 0644"  BSD_INSTALL_MAN="install  -m 444" /usr/bin/make DESTDIR=/usr/ports/devel/p5-B-Hooks-Parser/work/stage test
+ cd /usr/ports/devel/p5-B-Hooks-Parser/work/B-Hooks-Parser-0.13/
+ /usr/bin/env XDG_DATA_HOME=/usr/ports/devel/p5-B-Hooks-Parser/work XDG_CONFIG_HOME=/usr/ports/devel/p5-B-Hooks-Parser/work HOME=/usr/ports/devel/p5-B-Hooks-Parser/work NO_PIE=yes SHELL=/bin/sh NO_LINT=YES PREFIX=/usr/local LOCALBASE=/usr/local LIBDIR=/usr/lib CC=cc 'CFLAGS=-O2 -pipe  -fstack-protector -fno-strict-aliasing' CPP=cpp CPPFLAGS= 'LDFLAGS= -fstack-protector' LIBS= CXX=c++ 'CXXFLAGS=-O2 -pipe -fstack-protector -fno-strict-aliasing ' MANPREFIX=/usr/local 'BSD_INSTALL_PROGRAM=install  -s -m 555' 'BSD_INSTALL_LIB=install  -s -m 444' 'BSD_INSTALL_SCRIPT=install  -m 555' 'BSD_INSTALL_DATA=install  -m 0644' 'BSD_INSTALL_MAN=install  -m 444' /usr/bin/make DESTDIR=/usr/ports/devel/p5-B-Hooks-Parser/work/stage test
PERL_DL_NONLAZY=1 /usr/local/bin/perl5.18.4 "-MExtUtils::Command::MM" "-e" "test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
+ PERL_DL_NONLAZY=1 /usr/local/bin/perl5.18.4 -MExtUtils::Command::MM -e 'test_harness(0, '\''blib/lib'\'', '\''blib/arch'\'')' t/00-report-prereqs.t t/basic.t t/set_linestr.t t/toke.t
t/00-report-prereqs.t .. # 
# Versions for all modules listed in MYMETA.json (including optional ones):
# 
# === Configure Requires ===
# 
#     Module               Want  Have
#     ------------------- ----- -----
#     B::Hooks::OP::Check  0.18  0.19
#     ExtUtils::Depends   0.302 0.404
#     ExtUtils::MakeMaker   any  6.66
# 
# === Build Requires ===
# 
#     Module              Want Have
#     ------------------- ---- ----
#     ExtUtils::MakeMaker  any 6.66
# 
# === Test Requires ===
# 
#     Module               Want     Have
#     -------------------- ---- --------
#     B::Hooks::EndOfScope  any     0.15
#     ExtUtils::MakeMaker   any     6.66
#     File::Spec            any     3.40
#     Test::Exception       any     0.40
#     Test::More            any 1.001014
# 
# === Test Recommends ===
# 
#     Module         Want     Have
#     ---------- -------- --------
#     CPAN::Meta 2.120900 2.120921
# 
# === Runtime Requires ===
# 
#     Module              Want  Have
#     ------------------- ---- -----
#     B::Hooks::OP::Check  any  0.19
#     DynaLoader           any  1.18
#     parent               any 0.234
#     strict               any  1.07
#     warnings             any  1.18
# 
# === Other Modules ===
# 
#     Module           Have
#     ------------- -------
#     Pod::Coverage missing
# 
t/00-report-prereqs.t .. ok
t/basic.t .............. ok
t/set_linestr.t ........ Failed 2/2 subtests 
t/toke.t ............... ok

Test Summary Report
-------------------
t/set_linestr.t      (Wstat: 139 Tests: 0 Failed: 0)
  Non-zero wait status: 139
  Parse errors: Bad plan.  You planned 2 tests but ran 0.
Files=4, Tests=13,  8 wallclock secs ( 0.04 usr  0.02 sys +  7.93 cusr  0.05 csys =  8.04 CPU)
Result: FAIL
Failed 1/4 test programs. 0/13 subtests failed.
*** Error code 255

Stop.
make[1]: stopped in /usr/ports/devel/p5-B-Hooks-Parser/work/B-Hooks-Parser-0.13
*** Error code 1 (ignored)
root #

Script done on Sun Jul 19 12:06:41 2015
```

If appropriate to modify the ports file side

```
diff --git a/devel/p5-B-Hooks-Parser/Makefile b/devel/p5-B-Hooks-Parser/Makefile
index 83e89ff..f85e360 100644
--- a/devel/p5-B-Hooks-Parser/Makefile
+++ b/devel/p5-B-Hooks-Parser/Makefile
@@ -3,7 +3,7 @@

 PORTNAME=      B-Hooks-Parser
 PORTVERSION=   0.13
-PORTREVISION=  1
+PORTREVISION=  2
 CATEGORIES=    devel perl5
 MASTER_SITES=  CPAN
 PKGNAMEPREFIX= p5-
@@ -17,10 +17,21 @@ RUN_DEPENDS=        p5-B-Hooks-OP-Check>=0:${PORTSDIR}/devel/p5-B-Hooks-OP-Check
 TEST_DEPENDS=  p5-B-Hooks-EndOfScope>=0.05:${PORTSDIR}/devel/p5-B-Hooks-EndOfScope \
        p5-Test-Exception>=0:${PORTSDIR}/devel/p5-Test-Exception

-USES=          perl5
+USES=          perl5 compiler
 USE_PERL5=     configure

+.include <bsd.port.pre.mk>
+
+.if ${COMPILER_TYPE} == clang
+.if exists(${PERL})
+PERL_THREADS!=  ${PERL} -V::useithreads
+.if ${PERL_THREADS} == "'define';"
+CFLAGS+=       -O0
+.endif
+.endif
+.endif
+
 post-install:
    ${STRIP_CMD} ${STAGEDIR}${PREFIX}/${SITE_ARCH_REL}/auto/B/Hooks/Parser/Parser.so

-.include <bsd.port.mk>
+.include <bsd.port.post.mk>
```
