### PR TITLE
Fix hook_parser_setup() prototype

### DIFF
--- a/Parser.xs
+++ b/Parser.xs
@@ -1,3 +1,4 @@
+#define PERL_NO_GET_CONTEXT
 #include "EXTERN.h"
 #include "perl.h"
 #include "XSUB.h"
@@ -112,7 +113,7 @@ check_eval (pTHX_ OP *op, void *user_data) {
 }
 
 hook_op_check_id
-hook_parser_setup () {
+hook_parser_setup (pTHX) {
 	filter_add (grow_linestr, NULL);
 	return hook_op_check (OP_ENTEREVAL, check_eval, NULL);
 }
@@ -178,6 +179,10 @@ PROTOTYPES: DISABLE
 
 UV
 hook_parser_setup ()
+CODE:
+	RETVAL = hook_parser_setup (aTHX);
+OUTPUT:
+	RETVAL
 
 void
 hook_parser_teardown (id)

--- a/hook_parser.h
+++ b/hook_parser.h
@@ -4,7 +4,7 @@
 #include "perl.h"
 #include "hook_op_check.h"
 
-hook_op_check_id hook_parser_setup (void);
+hook_op_check_id hook_parser_setup (pTHX);
 void hook_parser_teardown (hook_op_check_id id);
 char *hook_parser_get_linestr (pTHX);
 IV hook_parser_get_linestr_offset (pTHX);

--- a/lib/B/Hooks/Parser.pm
+++ b/lib/B/Hooks/Parser.pm
@@ -91,7 +91,7 @@ is being held onto by the lexer.
 The following functions work just like their equivalent in the Perl API,
 except that they can't handle embedded C<NUL> bytes in strings.
 
-=head2 C<hook_op_check_id hook_parser_setup (void)>
+=head2 C<hook_op_check_id hook_parser_setup (pTHX)>
 
 =head2 C<void hook_parser_teardown (hook_op_check_id id)>
 


### PR DESCRIPTION
hook_parser_setup() needs to get the current interpreter for FILTER_ADD()
(actuall Perl_filter_add()). When PERL_NO_GET_CONTEXT is not defined,
the XS code is fetching it from PL_curinterp, but this confuses
clang, causing segfaults.

This commit changes the API so that hook_parser_setup() expects the
current interpreter at its sole parameter.

Note that backward compatibility may be preserved by defining the appropriate macro in hook_parser.h (see https://github.com/vpit/B-Hooks-Parser/tree/preserve-backcompat for example).
