### PR TITLE
Use exported fcns from perl core if available

### DIFF
--- a/Parser.xs
+++ b/Parser.xs
@@ -5,7 +5,7 @@
 #include "perl.h"
 #include "XSUB.h"
 
-#define NEED_PL_parser_GLOBAL
+#define NEED_PL_parser
 #include "ppport.h"
 
 #include "hook_parser.h"

--- a/Parser.xs
+++ b/Parser.xs
@@ -1,5 +1,10 @@
 #define __PARSER_XS__
 
+/* This has a too cosy relationship with the core, of necessity.  Define this
+ * so that the functions it needs are available, while they can still be
+ * restricted from normal XS modules (as long as they don't cheat) */
+#define PERL_EXT
+
 #define PERL_NO_GET_CONTEXT
 #include "EXTERN.h"
 #include "perl.h"
@@ -9,7 +14,12 @@
 #include "ppport.h"
 
 #include "hook_parser.h"
-#include "stolen_chunk_of_toke.c"
+
+/* Before perl core changed to give us access to these functions, we used a
+ * stolen (and outdated for many releases) copy */
+#if ! defined(scan_word) || ! defined(scan_str) || ! defined(skipspace_flags)
+#  include "stolen_chunk_of_toke.c"
+#endif
 
 #define NOT_PARSING (!PL_parser || !PL_bufptr)
 
@@ -167,12 +177,12 @@ hook_toke_scan_word (pTHX_ int offset, int handle_package, char *dest, STRLEN de
 
 char *
 hook_toke_skipspace (pTHX_ char *s) {
-	return skipspace (s);
+	return skipspace_flags (s, 0);
 }
 
 char *
 hook_toke_scan_str (pTHX_ char *s) {
-	return scan_str (s, 0, 0);
+	return scan_str (s, 0, 0, 0, NULL);
 }
 
 MODULE = B::Hooks::Parser  PACKAGE = B::Hooks::Parser  PREFIX = hook_parser_

--- a/stolen_chunk_of_toke.c
+++ b/stolen_chunk_of_toke.c
@@ -19,7 +19,7 @@
 
 #include "EXTERN.h"
 #include "perl.h"
-#define NEED_sv_2pv_flags
+#define NEED_PL_parser
 #include "ppport.h"
 
 /* the following #defines are stolen from assorted headers, not toke.c (mst) */
@@ -128,7 +128,7 @@ static const char c_in_subst[] =
 /* Invoke the idxth filter function for the current rsfp.	 */
 /* maxlen 0 = read one text line */
 I32
-filter_read(pTHX_ int idx, SV *buf_sv, int maxlen)
+Perl_filter_read(pTHX_ int idx, SV *buf_sv, int maxlen)
 {
     filter_t funcp;
     SV *datasv = NULL;

--- a/stolen_chunk_of_toke.c
+++ b/stolen_chunk_of_toke.c
@@ -24,10 +24,11 @@
 
 /* the following #defines are stolen from assorted headers, not toke.c (mst) */
 
-#define skipspace(a)            S_skipspace(aTHX_ a)
+#define skipspace_flags(a,b)    S_skipspace(aTHX_ a)
+#define skipspace(a)            skipspace_flags(a, 0)
 #define incline(a)              S_incline(aTHX_ a)
 #define filter_gets(a,b,c)      S_filter_gets(aTHX_ a,b,c)
-#define scan_str(a,b,c)         S_scan_str(aTHX_ a,b,c)
+#define scan_str(a,b,c,d,e)     S_scan_str(aTHX_ a,b,c)
 #define scan_word(a,b,c,d,e)    S_scan_word(aTHX_ a,b,c,d,e)
 
 STATIC void     S_incline(pTHX_ char *s);


### PR DESCRIPTION
You may want to drop the first one; I don't know where those changes came from nor what they should be.